### PR TITLE
I read the draft.

### DIFF
--- a/draft-ietf-rats-daa.md
+++ b/draft-ietf-rats-daa.md
@@ -6,6 +6,7 @@ abbrev: DAA for RATS
 docname: draft-ietf-rats-daa-latest
 wg: RATS Working Group
 area: Security
+stream: IETF
 kw: Internet-Draft
 cat: info
 

--- a/draft-ietf-rats-daa.md
+++ b/draft-ietf-rats-daa.md
@@ -1,21 +1,25 @@
 ---
+v: 3
+
 title: Direct Anonymous Attestation for the Remote Attestation Procedures Architecture
 abbrev: DAA for RATS
 docname: draft-ietf-rats-daa-latest
 wg: RATS Working Group
-stand_alone: true
-ipr: trust200902
 area: Security
 kw: Internet-Draft
 cat: info
-pi:
-  toc: yes
-  sortrefs: yes
-  symrefs: yes
+
+# colour neighbour randomise
+# [OXFORD_SPELLING_Z_NOT_S] Would you like to use the Oxford spelling “randomize”? The spelling ‘randomise’ is also correct. -> (randomize)
+
+venue:
+  group: Remote ATtestation ProcedureS (rats)
+  mail: rats@ietf.org
+  github: ietf-rats-wg/draft-ietf-rats-daa
+
 
 author:
-- ins: H. Birkholz
-  name: Henk Birkholz
+- name: Henk Birkholz
   org: Fraunhofer SIT
   abbrev: Fraunhofer SIT
   email: henk.birkholz@sit.fraunhofer.de
@@ -23,46 +27,25 @@ author:
   code: '64295'
   city: Darmstadt
   country: Germany
-- ins: C. Newton
-  name: Christopher Newton
+- name: Christopher Newton
   org: University of Surrey
   email: cn0016@surrey.ac.uk
-- ins: L. Chen
-  name: Liqun Chen
+- name: Liqun Chen
   org: University of Surrey
   email: liqun.chen@surrey.ac.uk
-- ins: D. Thaler
-  name: Dave Thaler
+- name: Dave Thaler
   org: Microsoft
   email: dthaler@microsoft.com
-  street: ""
-  code: ""
-  city: ""
-  region: ""
   country: USA
 
 normative:
-  RFC2119:
   RFC5280:
-  RFC8174:
-  DAA:
-    title: Direct Anonymous Attestation
-    author:
-    - ins: E. Brickell
-      name: Ernie Brickell
-    - ins: J. Camenisch
-      name: Jan Camenisch
-    - ins: L. Chen
-      name: Liqun Chen
-    seriesinfo:
-      ACM: >
-        Proceedings of the 11rd ACM conference on Computer and Communications Security
-      page: 132-145
-    date: 2004
+  DAA: DOI.10.1145/1030083.1030103
 
 informative:
   I-D.ietf-rats-architecture: RATS
   I-D.ietf-rats-reference-interaction-models: models
+  PBA: DOI.10.1007/978-3-540-85886-7_3
 
 --- abstract
 
@@ -91,12 +74,13 @@ Attester Identity, Authentication Secret, Authentication Secret ID
 
 A PKIX Certificate is an X.509v3 format certificate as specified by {{RFC5280}}.
 
-{::boilerplate bcp14}
+{::boilerplate bcp14-tagged}
 
 # Direct Anonymous Attestation
 
 {{dataflows}} shows the data flows between the different RATS roles involved in DAA.
 
+<!-- this would benefit from aasvg -->
 ~~~~
   ************       *************   ************   *****************
   * Endorser *       * Reference *   * Verifier *   * Relying Party *
@@ -138,10 +122,10 @@ To be able to sign anonymously, an Attester has to obtain a credential from a DA
 The DAA Issuer uses a private/public key pair to generate credentials for a group of Attesters <!-- this could be phrased a bit confusing as below it is stated that the key-pair is used for a group of Attesters --> and makes the public key (in the form of a public key certificate) available to the verifier in order to enable them to validate the Evidence received.
 
 In order to support these DAA signatures, the DAA Issuer MUST associate a single key pair with a group of Attesters <!-- is it clear enough what exactly "a group of Attesters" means? --> and use the same key pair when creating the credentials for all of the Attesters in this group.
-The DAA Issuer’s group public key certificate replaces the individual  Attester Identity documents during authenticity validation as a part of the appraisal of Evidence conducted by a verifier.
+The DAA Issuer’s group public key certificate replaces the individual Attester Identity documents during authenticity validation as a part of the appraisal of Evidence conducted by a verifier.
 This is in contrast to intuition that there has to be a unique Attester Identity per device.
 
-For DAA, the role of the Endorser is essentially the same, but they now  provide Attester endorsement documents to the DAA Issuer rather than directly to the verifier. These Attester endorsement documents enable the Attester to obtain a credential from the DAA Issuer.
+For DAA, the role of the Endorser is essentially the same, but they now provide Attester endorsement documents to the DAA Issuer rather than directly to the verifier. These Attester endorsement documents enable the Attester to obtain a credential from the DAA Issuer.
 
 # DAA changes to the RATS Architecture
 
@@ -149,7 +133,7 @@ In order to enable the use of DAA, a new conceptual message, the Credential Requ
 
 Credential Request:
 
-: An Attester sends a Credential Request to the DAA Issuer to obtain a credential. This request contains information about the DAA key that the Attester will use to  create evidence and together with Attester endorsement information that is provided by the Endorser to confirm that the request came from a valid Attester.
+: An Attester sends a Credential Request to the DAA Issuer to obtain a credential. This request contains information about the DAA key that the Attester will use to create evidence and, together with Attester endorsement information that is provided by the Endorser, to confirm that the request came from a valid Attester.
 
 DAA Issuer:
 
@@ -158,13 +142,14 @@ DAA Issuer:
 Effectively, these certificates share the semantics of Endorsements, with the following exceptions:
 
 * Upon receiving a Credential Request from an Attester, the associated group private key is used by the DAA Issuer to provide the Attester with a credential that it can use to convince the Verifier that its Evidence is valid.
-To keep their anonymity the Attester randomizes this credential each time that it is used. Although the DAA Issuer knows the Attester Identity and can associate this with the credential issued, randomisation ensures that the Attester's  identity cannot be revealed to anyone, including the Issuer.
-* The Verifier can use the DAA Issuer's group public key certificate, together with the randomized credential from the Attester, to confirm that the Evidence comes from a valid Attester without revealing the Attester's identity.
+To keep their anonymity, the Attester randomises this credential each time that it is used. Although the DAA Issuer knows the Attester Identity and can associate this with the credential issued, randomisation ensures that the Attester's identity cannot be revealed to anyone, including the DAA Issuer.
+* The Verifier can use the DAA Issuer's group public key certificate, together with the randomised credential from the Attester, to confirm that the Evidence comes from a valid Attester without revealing the Attester's identity.
 * A credential is conveyed from a DAA Issuer to an Attester in combination with the conveyance of the group public key certificate from DAA Issuer to Verifier.
 
 # Additions to Remote Attestation principles
 
 In order to ensure an appropriate conveyance of Evidence via interaction models in general, the following prerequisite considering Attester Identity MUST be in place to support the implementation of interaction models.
+<!-- This is a weird MUST: It is not clear who MUST do what here. -->
 
 Attestation Evidence Authenticity:
 
@@ -172,7 +157,7 @@ Attestation Evidence Authenticity:
 
 : In order to provide proofs of authenticity, Attestation Evidence SHOULD be cryptographically associated with an identity document that is a randomised DAA credential.
 
-The following information elements define extensions for corresponding information elements defined in {{-models}} and that are vital to all types of reference interaction models.
+The following information elements define extensions for corresponding information elements defined in {{-models}}, which are vital to all types of reference interaction models.
 Varying from solution to solution, generic information elements can be either included in the scope of protocol messages (instantiating Conceptual Messages defined by the RATS architecture) or can be included in additional protocol parameters of protocols that facilitate the conveyance of RATS Conceptual Messages.
 Ultimately, the following information elements are required by any kind of scalable remote attestation procedure using DAA with one of RATS's reference interaction models.
 
@@ -194,26 +179,25 @@ This is because an Attesting Environment should not be distinguishable and the D
 
 # Privacy Considerations
 
-As outlined about for DAA to provide privacy for the Attester the DAA group must be large enough to stop the Verifier identifying the Attester.
+As outlined above, for DAA to provide privacy for the Attester, the DAA group must be large enough to stop the Verifier identifying the Attester.
 
-Randomization of the DAA credential by the Attester means that collusion between the DAA Issuer and Verifier, will not give them any advantage when trying to identify the Attester.
+Randomisation of the DAA credential by the Attester means that collusion between the DAA Issuer and Verifier, will not give them any advantage when trying to identify the Attester.
 
-For DAA, the Attestation Evidence conveyed to the Verifier MUST not uniqely identify the Attester. If the Attestation Evidence is unique to an Attester other cryptographic techniques can be used, for example, property based attestation.
-(Henk -- reference follows)
-
-Chen L., Löhr H., Manulis M., Sadeghi AR. (2008) Property-Based Attestation without a Trusted Third Party. Information Security. ISC 2008. Lecture Notes in Computer Science, vol 5222. Springer. https://doi.org/10.1007/978-3-540-85886-7_3
+For DAA, the Attestation Evidence conveyed to the Verifier MUST not uniquely identify the Attester. If the Attestation Evidence is unique to an Attester other cryptographic techniques can be used, for example, property based attestation [PBA].
 
 # Security Considerations
 
 The anonymity property of DAA makes revocation difficult. Well known solutions include:
-1. Rogue attester revocation -- if the an Attester's private key is compromised and known by the Verifier then any DAA signature from that Attester can be revoked.
+
+1. Rogue Attester revocation -- if an Attester's private key is compromised and known by the Verifier then any DAA signature from that Attester can be revoked.
 2. EPID - Intel's Enhanced Privacy ID -- this requires the Attester to prove (as part of their Attestation) that their credential was not used to generate any signature in a signature revocation list.
 
-There are no other special security conderations for DAA over and above those specifed in the RATS architecture document {{-RATS}}.
+There are no other special security considerations for DAA over and above those specified in the RATS architecture document {{-RATS}}.
 
 # Implementation Considerations
 
 The new DAA Issuer role can be implemented in a number of ways, for example:
+
 1. As a stand-alone service like a Certificate Authority, a Privacy CA.
 2. As a part of the Attester's manufacture. The Endorser and the DAA Issuer could be the same entity and the manufacturer would then provide a certificate for the group public key to the Verifier.
 


### PR DESCRIPTION
A few bits of kramdown-rfc housekeeping, typos, missing commas,
reference fixes.

Please update your local systems to kramdown-rfc 1.6.14 in case the
bugs recently introduced on bib.ietf.org bite.

The dialect was mixed; I normalized to British English.
(Please fix this to American English :-)

I didn't try to address the BCP14 usage; some of the MUSTs are not
interoperability mandates, but more like general statements about what
would be good for the state of the world.

The HTML/PDF rendering of Figure 1 would benefit from aasvg; I didn't
make the necessary changes because I don't know if you have that
installed (npm install -g aasvg).